### PR TITLE
refactor: replace ListElement with TreeElement

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,9 +13,9 @@ const filePath = join('data', 'files')
 let contactList: Array<Contact>
 let friendList: Array<Contact>
 let roomList: Array<Room>
-let contactMap = new Map()
-let roomMap = new Map()
-let msgStore = new Map()
+let contactByName = new Map()
+let roomByName = new Map()
+let msgByContact  = new Map()
 
 function onLogout (user: Contact, logElement: any) {
   logElement.log('StarterBot', '%s logout', user)
@@ -46,23 +46,23 @@ async function onReady(logElement: contrib.Widgets.LogElement) {
     bot.say('Wechaty ready!').catch(console.error)
     contactList = await bot.Contact.findAll()
     friendList = contactList.filter(x => x.type() !== Contact.Type.Official)
-    // contactMap = friendList.reduce(async (acc, friend) => {
+    // contactByName = friendList.reduce(async (acc, friend) => {
     //   const key = await friend.alias() || friend.name()
     //   return acc.set(key, friend);
-    // }, contactMap)
+    // }, contactByName)
     for (const friend of contactList) {
       const key = await friend.alias() || friend.name()
-      contactMap.set(key.toString(), friend)
+      contactByName.set(key.toString(), friend)
     }
-    leftPanel.setItems([...contactMap.keys()])
+    leftPanel.setItems([...contactByName.keys()])
     msgConsole.log(`Totally ${friendList.length} friends`)
-    const roomList = await bot.Room.findAll()
+    roomList = await bot.Room.findAll()
     for (const room of roomList) {
       const key = await room.topic() || room.id
-      roomMap.set(key, room)
+      roomByName.set(key, room)
     }
     msgConsole.log(`Totally ${roomList.length} rooms`)
-    leftPanel.setItems([...roomMap.keys()])
+    leftPanel.setItems([...roomByName.keys()])
     screen.render()
     leftPanel.focus()
 }
@@ -71,7 +71,7 @@ async function onMessage(message: Message, logElement: contrib.Widgets.LogElemen
   const type = message.type()
   logElement.log(message.toString())
   const talker = message.talker()
-  msgStore.set(talker, message)
+  msgByContact.set(talker, message)
   if (type != Message.Type.Text) {
       const file = await message.toFileBox()
       const folder = join(filePath, bot.userSelf().name())

--- a/index.ts
+++ b/index.ts
@@ -2,20 +2,33 @@ import { join } from 'path'
 import { mkdirSync } from 'fs'
 import { Contact, Message, Room, ScanStatus, Wechaty } from 'wechaty'
 import { generate } from 'qrcode-terminal'
-import { screen, msgConsole, leftPanel } from './src/main'
+import { screen, msgConsole, leftPanel, rightPanel } from './src/main'
 import * as blessed from 'blessed'
 import * as contrib from 'blessed-contrib'
 
-const bot = new Wechaty()
+const bot = new Wechaty({name: 'test'})
 const filePath = join('data', 'files')
 
 // name must be unique
 let contactList: Array<Contact>
 let friendList: Array<Contact>
 let roomList: Array<Room>
-let contactByName = new Map()
-let roomByName = new Map()
-let msgByContact  = new Map()
+let friendByName: Map<string, Contact> = new Map()
+let roomByName: Map<string, Room> = new Map()
+let msgByName: Map<string, Array<Message>>  = new Map()
+let membersByRoom: Map<Room, Contact[]> = new Map()
+
+function toBlessedText (s: string, p: blessed.Widgets.Node) {
+  return blessed.text({parent: p, content: s})
+}
+
+async function getKey(s: Contact | Room) {
+  if (s instanceof Contact) {
+    return await s.alias() || s.name() || s.id
+  } else {
+    return await s.topic() || s.id
+  }
+}
 
 function onLogout (user: Contact, logElement: any) {
   logElement.log('StarterBot', '%s logout', user)
@@ -42,36 +55,32 @@ function onLogin(user: Contact, logElement: any) {
     logElement.setLabel(logElement._label.content + ' - ' + user.name())
 }
 
+// when login complete, get all friend/room then display on the leftPanel
 async function onReady(logElement: contrib.Widgets.LogElement) {
     bot.say('Wechaty ready!').catch(console.error)
+
     contactList = await bot.Contact.findAll()
     friendList = contactList.filter(x => x.type() !== Contact.Type.Official)
-    // contactByName = friendList.reduce(async (acc, friend) => {
-    //   const key = await friend.alias() || friend.name()
-    //   return acc.set(key, friend);
-    // }, contactByName)
-    for (const friend of contactList) {
-      const key = await friend.alias() || friend.name()
-      contactByName.set(key.toString(), friend)
-    }
-    leftPanel.setItems([...contactByName.keys()])
+    await Promise.all(friendList.map(async f => friendByName.set(await getKey(f), f)));
+    [...friendByName.keys()].forEach(f => leftPanel.add(f))
     msgConsole.log(`Totally ${friendList.length} friends`)
+    msgConsole.log(friendByName.size.toString())
+
     roomList = await bot.Room.findAll()
-    for (const room of roomList) {
-      const key = await room.topic() || room.id
-      roomByName.set(key, room)
-    }
-    msgConsole.log(`Totally ${roomList.length} rooms`)
-    leftPanel.setItems([...roomByName.keys()])
+    await Promise.all(roomList.map(async f => roomByName.set(await getKey(f), f)));
+    [...roomByName.keys()].forEach(r => leftPanel.add(r))
+    msgConsole.log(`Totally ${roomList.length} rooms`);
+    msgConsole.log(roomByName.size.toString())
     screen.render()
-    leftPanel.focus()
 }
 
 async function onMessage(message: Message, logElement: contrib.Widgets.LogElement) {
   const type = message.type()
   logElement.log(message.toString())
-  const talker = message.talker()
-  msgByContact.set(talker, message)
+  const source = message.room() || message.talker()
+  const k = await getKey(source)
+  if (!msgByName.has(k)) msgByName.set(k,[])
+  msgByName.get(k)!.push(message)
   if (type != Message.Type.Text) {
       const file = await message.toFileBox()
       const folder = join(filePath, bot.userSelf().name())
@@ -107,6 +116,40 @@ function startBot(bot: Wechaty, logElement: any) {
     process.exit(-1)
   })
 }
+
+leftPanel.on('select item', async (item, index) => {
+  const name = item.getContent().trim()
+  msgConsole.setContent('')
+  rightPanel.setContent('')
+  const msgs = msgByName.get(name) || ['No message!']
+  msgs.forEach(m => msgConsole.add(m.toString()))
+  const source: Contact | Room | undefined = friendByName.get(name) || roomByName.get(name)
+  msgConsole.log(name)
+  msgConsole.log(friendByName.has(name).toString())
+  msgConsole.log(roomByName.has(name).toString())
+  if(source === undefined) {  // 所有中文字符都失败
+    msgConsole.log('error: source no found')
+    // click '李涵' to test a specified name
+    msgConsole.log('李涵')
+    msgConsole.log(`name == '李涵' ${name == '李涵'}`) // false! although they are displayed the same
+    msgConsole.log(`friendByName.has('李涵') ${friendByName.has('李涵')}`)  
+    // Array.from(friendByName.keys()).forEach(s => msgConsole.log(s))
+  } else {
+    msgConsole.log(await getKey(source))
+  }
+  if (source instanceof Room) {
+    if(membersByRoom.has(source)) membersByRoom.set(source, await source.memberAll())
+    const members = membersByRoom.get(source)
+    rightPanel.setitems(members?.map(m => getKey(m)))
+  }
+})
+
+leftPanel.on('cancel item', (item, index) => {
+  const name = item.getText()
+  msgConsole.setContent('')
+  msgConsole.log(name + 'cancel')
+  const msgs = [...msgByName.values()].forEach(m => msgConsole.add(m.toString()))
+})
 
 async function main() {
   startBot(bot, msgConsole)

--- a/package.json
+++ b/package.json
@@ -15,5 +15,10 @@
     "blessed-contrib": "^4.8.21",
     "qrcode-terminal": "^0.12.0",
     "wechaty": "^0.62.3"
+  },
+  "devDependencies": {
+    "tsconfig-paths": "^3.10.1",
+    "wechaty-puppet-wechat": "^0.28.3",
+    "wechaty-puppet-wechat4u": "^0.18.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "chinggg",
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/blessed": "^0.1.17",
+    "@types/blessed": "^0.1.19",
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.8.21",
     "qrcode-terminal": "^0.12.0",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,10 @@
+export interface TreeNode {
+	name?: string,
+	children?: TreeChildren | ((node: TreeNode) => TreeChildren | Promise<TreeChildren>),
+	childrenContent?: TreeChildren,
+	extended?: boolean,
+	parent?: TreeNode,
+	[custom: string]: any
+}
+
+export type TreeChildren = Record<string, TreeNode>

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ const prompt = blessed.prompt({
 
 const grid = new contrib.grid({rows: 12, cols: 12, screen: screen})
 
-const leftPanel = grid.set(0, 0, 12, 3, blessed.list, {
+const leftPanel: blessed.Widgets.ListElement = grid.set(0, 0, 12, 3, blessed.list, {
   label: 'Contact List',
   ...scrollOption,
   style: listStyle,
@@ -28,16 +28,16 @@ const leftPanel = grid.set(0, 0, 12, 3, blessed.list, {
   }
 })
 
-const msgConsole = grid.set(0, 3, 12, 6, contrib.log, {
+const msgConsole: blessed.Widgets.Log = grid.set(0, 3, 12, 7, blessed.log, {
   fg: 'green',
   selectedFg: 'green',
   label: 'Messages',
   ...scrollOption
 })
-const rightPanel = grid.set(0, 9, 12, 3, blessed.list, {label: 'Options'})
+const rightPanel = grid.set(0, 10, 12, 2, blessed.list, {label: 'Options'})
 
-screen.key(['escape', 'C-c', 'C-d'], function(ch, key) {
+screen.key(['C-c', 'C-d'], function(ch, key) {
   return process.exit(0);
 });
 
-export { screen, grid, msgConsole, leftPanel }
+export { screen, grid, msgConsole, leftPanel, rightPanel }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,35 +1,42 @@
 import * as blessed from 'blessed'
 import * as contrib from 'blessed-contrib'
+import { screenOption, scrollOption, navigateOption, listStyle } from './options'
 
-const screen = blessed.screen({
-    smartCSR:       true,
-    fullUnicode:    true,
-})
+const screen = blessed.screen(screenOption)
 screen.title = 'wechaty-cli'
 
+const prompt = blessed.prompt({
+  parent: screen,
+  tags: true,
+  border: 'line',
+  hidden: true,
+  ...navigateOption
+});
 
 const grid = new contrib.grid({rows: 12, cols: 12, screen: screen})
+
 const leftPanel = grid.set(0, 0, 12, 3, blessed.list, {
   label: 'Contact List',
-  alwaysScroll: true,
-  scrollable: true,
-  scrollbar: {
-    style: {
-      bg: 'yellow'
-    }
-  },
-  mouse: true,
-  keys: true,
-  vi: true
+  ...scrollOption,
+  style: listStyle,
+  // TO DO: search does not work
+  search: (callback: (arg0: any, arg1: string) => void) => {
+    prompt.input('Search:', '', function(err, value) {
+      if (err) return;
+      return callback(null, value);
+    });
+  }
 })
+
 const msgConsole = grid.set(0, 3, 12, 6, contrib.log, {
   fg: 'green',
   selectedFg: 'green',
   label: 'Messages',
+  ...scrollOption
 })
-const rightPanel = grid.set(0, 9, 12, 3, contrib.tree, {label: 'Options'})
+const rightPanel = grid.set(0, 9, 12, 3, blessed.list, {label: 'Options'})
 
-screen.key(['escape', 'C-c'], function(ch, key) {
+screen.key(['escape', 'C-c', 'C-d'], function(ch, key) {
   return process.exit(0);
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,38 +5,27 @@ import { screenOption, scrollOption, navigateOption, listStyle } from './options
 const screen = blessed.screen(screenOption)
 screen.title = 'wechaty-cli'
 
-const prompt = blessed.prompt({
-  parent: screen,
-  tags: true,
-  border: 'line',
-  hidden: true,
-  ...navigateOption
-});
-
 const grid = new contrib.grid({rows: 12, cols: 12, screen: screen})
 
-const leftPanel: blessed.Widgets.ListElement = grid.set(0, 0, 12, 3, blessed.list, {
+const leftPanel: contrib.Widgets.TreeElement = grid.set(0, 0, 12, 3, contrib.tree, {
   label: 'Contact List',
   ...scrollOption,
+  vi: true,
+  mouse: true,
   style: listStyle,
-  // TO DO: search does not work
-  search: (callback: (arg0: any, arg1: string) => void) => {
-    prompt.input('Search:', '', function(err, value) {
-      if (err) return;
-      return callback(null, value);
-    });
-  }
 })
 
-const msgConsole: blessed.Widgets.Log = grid.set(0, 3, 12, 7, blessed.log, {
+const msgConsole: contrib.Widgets.LogElement = grid.set(0, 3, 12, 7, blessed.log, {
   fg: 'green',
   selectedFg: 'green',
   label: 'Messages',
+  ...navigateOption,
   ...scrollOption
 })
-const rightPanel = grid.set(0, 10, 12, 2, blessed.list, {label: 'Options'})
 
-screen.key(['C-c', 'C-d'], function(ch, key) {
+const rightPanel = grid.set(0, 10, 12, 2, contrib.tree, {label: 'Options'})
+
+screen.key(['escape', 'C-c', 'C-d'], function(ch, key) {
   return process.exit(0);
 });
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ export const screenOption = {
   useBCE: true,
   autoPadding: true,
   dockBorders: true,
+  forceUnicode: true,
   fullUnicode: true,
   sendFocus: true,
   warnings: true

--- a/src/options.ts
+++ b/src/options.ts
@@ -23,7 +23,7 @@ export const listStyle = {
 
 export const navigateOption = {
   mouse: true,
-  keys: true,
+  keys: true,  // conflict with TreeElement keys: string[]
   vi: true
 }
 
@@ -39,5 +39,4 @@ export const scrollOption = {
       inverse: true
     }
   },
-  ...navigateOption
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,42 @@
+export const screenOption = {
+  smartCSR: true,
+  useBCE: true,
+  autoPadding: true,
+  dockBorders: true,
+  fullUnicode: true,
+  sendFocus: true,
+  warnings: true
+}
+
+export const listStyle = {
+  item: {
+    hover: {
+      bg: 'blue'
+    }
+  },
+  selected: {
+    bg: 'blue',
+    bold: true
+  }
+}
+
+export const navigateOption = {
+  mouse: true,
+  keys: true,
+  vi: true
+}
+
+export const scrollOption = {
+  clickable: true,
+  scrollable: true,  // If scrollable option is enabled, Element inherits all methods from ScrollableBox
+  // alwaysScroll: true,
+  scrollbar: {
+    track: {
+      bg: 'cyan'
+    },
+    style: {
+      inverse: true
+    }
+  },
+  ...navigateOption
+}


### PR DESCRIPTION
This PR is an **incomplete** attempt to solve #9 , it will **crash** whenever the leftPanel is focused.

Since TreeElement requires single root to `setData()`, I make a pseudo-root named `panelRoot` which has record of `friendRoot` and `roomRoot` as its children. It make the tree more complex, i.e. more unstable, but the advantage is maximized utilization of space by folding one of the two roots.
To display contacts and rooms as two tree elements maybe more straightforward and less error-prone, though the available space will be reduced by half. We can discuss it later in #9.
![image](https://user-images.githubusercontent.com/24590067/127737136-565359fc-eaad-4d56-a929-82aa807dedac.png)

@huan If you see no big problem in this PR, it can be merged/rebased/squashed(up to you since I am not familiar with the common practice) into the `dev` branch. After that I will add more infos like icons and descriptions to `README.md` then make another PR to `main` branch.
