### PR TITLE
fix crash caused by scrollable leftPanel

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,14 +5,39 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"name": "Launch via NPM",
+			"request": "launch",
+			"runtimeArgs": [
+				"start",
+			],
+			"runtimeExecutable": "npm",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"type": "pwa-node",
+			"console": "integratedTerminal",
+		},
+		{
             "name": "Attach",
             "request": "attach",
-            "type": "pwa-node",
             "port": 9229,
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+            "type": "pwa-node",
 			// "resolveSourceMapLocations": [
 			// 	"${workspaceFolder}/**",
 			// 	"!**/node_modules/**"
 			// ]
-        }
+        },
+		{
+			"name": "Attach by Process ID",
+			"processId": "${command:PickProcess}",
+			"request": "attach",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"type": "pwa-node"
+		},
 	]
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ npm start
 
 ### Debug in VS Code
 
-First run `npm run debug` in terminal, then run VS Code debugger with F5
+Debugging with configuration "Launch via NPM", the app will run immediately in the integrated terminal.
+
+To test the app in external terminal, run `npm run debug` then start debugging with configuration "Attach".
 
 ## Resources
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -57,7 +57,7 @@ function onLogin (user: Contact, logElement: any) {
 }
 
 // when login complete, get all friend/room then display on the leftPanel
-async function onReady(_logElement: contrib.Widgets.LogElement) {
+async function onReady(logElement: contrib.Widgets.LogElement) {
   bot.say('Wechaty ready!').catch(console.error)
 
   contacts = await bot.Contact.findAll()
@@ -78,7 +78,7 @@ async function onReady(_logElement: contrib.Widgets.LogElement) {
     children: friendRecord
   }
   leftPanel.setData(friendRoot)
-  msgConsole.log(`Totally ${friends.length} friends`)
+  logElement.log(`Totally ${friends.length} friends`)
 
   rooms = await bot.Room.findAll();
   for (const r of rooms) {
@@ -102,10 +102,9 @@ async function onReady(_logElement: contrib.Widgets.LogElement) {
     children: {'Friends': friendRoot, 'Rooms': roomRoot}
   }
   leftPanel.setData(panelRoot)
-  msgConsole.log(`Totally ${rooms.length} rooms`);
+  logElement.log(`Totally ${rooms.length} rooms`);
 
-  // TO DO: Fix crash
-  // leftPanel.focus()
+  leftPanel.focus()
   screen.render()
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ const grid = new contrib.grid({
 
 const leftPanel: contrib.Widgets.TreeElement = grid.set(0, 0, 12, 3, contrib.tree, {
   label: 'Contact List',
-  ...scrollOption,
+  // ...scrollOption,
   mouse: true,
   style: listStyle,
   vi: true,


### PR DESCRIPTION
As I have found the reason of crash in #9, there can be two approaches to fix it. One is to modify the line `if (this.screen.focused === this.rows) this.rows.focus();` in `tree.render()` which confuses me a lot. Another is to make `tree.scrollable` evaluated to `false` so `screen._focus()` will not call `screen.render()`, which in turn calls `tree.render()`, thus leading to the infinite loop.

I remember I have tested to remove `scrollOption` for `leftPanel` and it still crashed with `tree.scrollable` evaluated to `true`.
But today it doesn't! So the quick fix is to make leftPanel unscrollable by removing `scrollOption`.